### PR TITLE
Aa/get fixes

### DIFF
--- a/server/controllers/artController.js
+++ b/server/controllers/artController.js
@@ -207,7 +207,7 @@ const artController = {
 
     async findArt(request, response, next) {
         try {
-            const queriedEmotion = request.body.emotion;
+            const queriedEmotion = request.params.emotion;
             const returnedArt = await Art.find({ emotion: queriedEmotion })
             response.locals.foundArt = returnedArt;
             return next()

--- a/server/routes/artApi.js
+++ b/server/routes/artApi.js
@@ -4,7 +4,7 @@ const artController = require('../controllers/artController')
 const userController = require('../controllers/userController')
 
 
-router.get('/', artController.findArt, (req, res) => res.status(200).json(res.locals.foundArt))
+router.get('/fetchArt/:emotion', artController.findArt, (req, res) => res.status(200).json(res.locals.foundArt))
 
 router.patch('/vote', userController.verifyToken, artController.vote, (req, res) => res.status(200).json(res.locals.voted))
 


### PR DESCRIPTION
## Overview

**Issue Type**

- [x] Bug
- [ ] Feature
- [ ] Tech Debt

**Description**
Fixed get route requiring a body. Now, submit get requests to art/fetchArt/{emotion} for same effect.


**Expected behavior**
Submitting get requests to art/fetchArt/{emotion} now replaces GET to art/